### PR TITLE
Prevent test files from being converted to CRLF on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.test      eol=lf


### PR DESCRIPTION
On windows, git `autocrlf`'s default behavior automatically replaces LF by CRLF when `git clone`, resulting in fail to parse test files.
Alternatives: Making Conformance eol agonostic by converting CRLF to LF before splitting test files.

```rs
PS C:\tinyc> cargo test
    Blocking waiting for file lock on build directory
   Compiling conformance v0.2.0 (C:\tinyc\crates\conformance)
   Compiling tinyc_lexer v0.1.0 (C:\tinyc\crates\lexer)                                               
   Compiling tinyc_parser v0.1.0 (C:\tinyc\crates\parser)
error: file has disallowed content after final `...`

error: file has disallowed content after final `...`
  --> crates\lexer\tests\harness.rs:18:46
   |
18 | #[conformance::tests(exact, serde=yaml, file="tests/KartikTalwar.yaml.test")]
   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `json`, `ron`, `yaml`
 --> crates\lexer\tests\harness.rs:2:18
  |
2 |     conformance, json, ron,
  |                  ^^^^  ^^^
3 |     tinyc_lexer::{tokenize, Token},
4 |     yaml,
  |     ^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
error: aborting due to 2 previous errors; 1 warning emitted

error: could not compile `tinyc_lexer`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```